### PR TITLE
Fix center_rows_and_columns to honor copy_layer when source is .X

### DIFF
--- a/src/shackett_utils/genomics/adata_processing.py
+++ b/src/shackett_utils/genomics/adata_processing.py
@@ -3,6 +3,7 @@ This module contains functions for data normalization and transformation.
 """
 
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Tuple, List, Dict, Union, Optional
 import warnings
 
@@ -11,6 +12,12 @@ import scipy.sparse as sp
 from anndata import AnnData
 
 import matplotlib.pyplot as plt
+
+
+CENTERING_DEFS = SimpleNamespace(
+    DEFAULT_NAME_TEMPLATE="{layer}_centered",
+    DEFAULT_NAME_NOLAYER="centered",
+)
 
 
 def plot_feature_counts_histogram(
@@ -431,16 +438,19 @@ def center_rows_and_columns(
         )
 
     # Store the result
-    if layer is None:
+    if copy_layer:
+        # Determine new layer name
+        if new_layer_name is None:
+            new_layer_name = (
+                CENTERING_DEFS.DEFAULT_NAME_TEMPLATE.format(layer=layer)
+                if layer
+                else CENTERING_DEFS.DEFAULT_NAME_NOLAYER
+            )
+        adata.layers[new_layer_name] = matrix
+    elif layer is None:
         adata.X = matrix
     else:
-        if copy_layer:
-            # Determine new layer name
-            if new_layer_name is None:
-                new_layer_name = f"{layer}_centered" if layer else "centered"
-            adata.layers[new_layer_name] = matrix
-        else:
-            adata.layers[layer] = matrix
+        adata.layers[layer] = matrix
 
     if not inplace:
         return adata

--- a/src/tests/genomics/test_adata_processing.py
+++ b/src/tests/genomics/test_adata_processing.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pandas as pd
+import pytest
+import anndata as ad
+
+from shackett_utils.genomics.adata_processing import (
+    CENTERING_DEFS,
+    center_rows_and_columns,
+)
+
+
+@pytest.fixture
+def small_adata():
+    np.random.seed(0)
+    n_cells, n_genes = 20, 5
+    X = np.random.normal(loc=3.0, scale=1.0, size=(n_cells, n_genes))
+    return ad.AnnData(
+        X=X,
+        obs=pd.DataFrame(index=[f"c{i}" for i in range(n_cells)]),
+        var=pd.DataFrame(index=[f"g{i}" for i in range(n_genes)]),
+    )
+
+
+def test_copy_layer_with_x_does_not_modify_x(small_adata):
+    """copy_layer=True with layer=None must leave .X untouched and write a new layer."""
+    original_x = small_adata.X.copy()
+
+    center_rows_and_columns(small_adata, layer=None, copy_layer=True)
+
+    # .X must be unchanged
+    np.testing.assert_array_equal(small_adata.X, original_x)
+
+    # Default new layer name should exist and contain centered data
+    new_layer = CENTERING_DEFS.DEFAULT_NAME_NOLAYER
+    assert new_layer in small_adata.layers
+    centered = small_adata.layers[new_layer]
+    assert centered.shape == original_x.shape
+    assert not np.allclose(centered, original_x)
+    assert abs(centered.mean(axis=0)).max() < 1e-6
+    assert abs(centered.mean(axis=1)).max() < 1e-6
+
+
+def test_copy_layer_with_x_respects_custom_name(small_adata):
+    original_x = small_adata.X.copy()
+    center_rows_and_columns(
+        small_adata, layer=None, copy_layer=True, new_layer_name="my_centered"
+    )
+
+    np.testing.assert_array_equal(small_adata.X, original_x)
+    assert "my_centered" in small_adata.layers
+    assert CENTERING_DEFS.DEFAULT_NAME_NOLAYER not in small_adata.layers


### PR DESCRIPTION
## Summary
- `center_rows_and_columns(..., layer=None, copy_layer=True)` no longer silently overwrites `.X`. The centered result is written to a new layer (default `"centered"`, or a caller-supplied `new_layer_name`), and `.X` is left untouched.
- Default layer names extracted into `CENTERING_DEFS = SimpleNamespace(DEFAULT_NAME_TEMPLATE="{layer}_centered", DEFAULT_NAME_NOLAYER="centered")`.
- Added `src/tests/genomics/test_adata_processing.py` covering the `layer=None` + `copy_layer=True` case (both default and custom `new_layer_name`).

Closes #15 

## Test plan
- [x] `pytest src/tests/genomics/test_adata_processing.py` passes locally
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)